### PR TITLE
NCAPP-47: Support referencing automatically and manually set ids on images

### DIFF
--- a/application-numbered-content-reference/application-numbered-content-reference-macro/src/main/java/org/xwiki/contrib/numbered/content/reference/internal/ReferenceMacro.java
+++ b/application-numbered-content-reference/application-numbered-content-reference-macro/src/main/java/org/xwiki/contrib/numbered/content/reference/internal/ReferenceMacro.java
@@ -168,25 +168,23 @@ public class ReferenceMacro extends AbstractMacro<ReferenceMacroParameters>
     private boolean hasId(FigureBlock figureBlock, String id)
     {
         return figureBlock.getFirstBlock(block -> {
+            boolean result = false;
+
             String idParameter = block.getParameter(ID_PARAMETER_KEY);
             if (idParameter != null) {
                 // Match the id parameter of any block.
-                return Objects.equals(idParameter, id);
-            }
-
-            if (block instanceof IdBlock) {
+                result = Objects.equals(idParameter, id);
+            } else if (block instanceof IdBlock) {
                 // Match the id of the id block.
                 IdBlock idBlock = (IdBlock) block;
-                return Objects.equals(idBlock.getName(), id);
-            }
-
-            if (block instanceof ImageBlock) {
+                result = Objects.equals(idBlock.getName(), id);
+            } else if (block instanceof ImageBlock) {
                 // Match the id of the image block.
                 ImageBlock imageBlock = (ImageBlock) block;
-                return Objects.equals(imageBlock.getId(), id);
+                result = Objects.equals(imageBlock.getId(), id);
             }
 
-            return false;
+            return result;
         }, Block.Axes.DESCENDANT_OR_SELF) != null;
     }
 }

--- a/application-numbered-content-reference/application-numbered-content-reference-macro/src/main/java/org/xwiki/contrib/numbered/content/reference/internal/ReferenceMacro.java
+++ b/application-numbered-content-reference/application-numbered-content-reference-macro/src/main/java/org/xwiki/contrib/numbered/content/reference/internal/ReferenceMacro.java
@@ -19,8 +19,6 @@
  */
 package org.xwiki.contrib.numbered.content.reference.internal;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -84,13 +82,6 @@ public class ReferenceMacro extends AbstractMacro<ReferenceMacroParameters>
     private ContextualLocalizationManager l10n;
 
     /**
-     * The {@code getId}-method of the image block, using reflection to avoid depending on XWiki 14.2.
-     *
-     * @since 1.3
-     */
-    private final Method imageBlockGetIdMethod;
-
-    /**
      * Create and initialize the descriptor of the macro.
      */
     public ReferenceMacro()
@@ -98,8 +89,6 @@ public class ReferenceMacro extends AbstractMacro<ReferenceMacroParameters>
         super("Reference", DESCRIPTION, ReferenceMacroParameters.class);
         setDefaultCategory(DEFAULT_CATEGORY_NAVIGATION);
         setPriority(3000);
-        this.imageBlockGetIdMethod = Arrays.stream(ImageBlock.class.getDeclaredMethods())
-            .filter(m -> "getId".equals(m.getName())).findFirst().orElse(null);
     }
 
     @Override
@@ -191,15 +180,10 @@ public class ReferenceMacro extends AbstractMacro<ReferenceMacroParameters>
                 return Objects.equals(idBlock.getName(), id);
             }
 
-            if (block instanceof ImageBlock && this.imageBlockGetIdMethod != null) {
+            if (block instanceof ImageBlock) {
                 // Match the id of the image block.
                 ImageBlock imageBlock = (ImageBlock) block;
-
-                try {
-                    return Objects.equals(this.imageBlockGetIdMethod.invoke(imageBlock), id);
-                } catch (Exception ignored) {
-                    // Ignore invocation errors.
-                }
+                return Objects.equals(imageBlock.getId(), id);
             }
 
             return false;

--- a/application-numbered-content-reference/application-numbered-content-reference-macro/src/test/resources/references_figure.test
+++ b/application-numbered-content-reference/application-numbered-content-reference-macro/src/test/resources/references_figure.test
@@ -26,7 +26,7 @@ See table {{reference figure="t1"/}}.
 .#-----------------------------------------------------
 .expect|xhtml/1.0
 .#-----------------------------------------------------
-<p>See figure <span class="wikilink"><a href="#f1">1</a></span>.</p><p><img src="http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png" width="100" alt="http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png"/></p><p><span id="f1"></span>An image</p><p>See table <span class="wikilink"><a href="#t1">2</a></span>.</p><table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table><p><span id="t1"></span>A table</p>
+<p>See figure <span class="wikilink"><a href="#f1">1</a></span>.</p><p><img src="http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png" width="100" id="Ihttp:2F2Fwww.clker.com2Fcliparts2F32Fm2Fv2FY2FE2FV2Fsmall-red-apple-md.png" class="wikigeneratedid" alt="http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png"/></p><div class="figcaption"><p><span id="f1"></span>An image</p></div><p>See table <span class="wikilink"><a href="#t1">2</a></span>.</p><table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table><div class="figcaption"><p><span id="t1"></span>A table</p></div>
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
@@ -48,25 +48,27 @@ beginMacroMarkerStandalone [figure] [] [[[image:http://www.clker.com/cliparts/3/
 {{figureCaption}}
 {{id name="f1"/}}An image
 {{/figureCaption}}]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginParagraph
-onImage [Typed = [false] Type = [url] Reference = [http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png]] [false] [[width]=[100]]
+onImage [Typed = [false] Type = [url] Reference = [http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png]] [false] [Ihttp:2F2Fwww.clker.com2Fcliparts2F32Fm2Fv2FY2FE2FV2Fsmall-red-apple-md.png] [[width]=[100]]
 endParagraph
 beginMacroMarkerStandalone [figureCaption] [] [{{id name="f1"/}}An image]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigureCaption
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginParagraph
 beginMacroMarkerInline [id] [name=f1]
 onId [f1]
 endMacroMarkerInline [id] [name=f1]
 onWord [An]
 onSpace
 onWord [image]
+endParagraph
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
-endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endMacroMarkerStandalone [figureCaption] [] [{{id name="f1"/}}An image]
-endFigure
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] [] [[[image:http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png||width="100"]]
 
 {{figureCaption}}
@@ -90,8 +92,8 @@ beginMacroMarkerStandalone [figure] [] [|a|b
 {{figureCaption}}
 {{id name="t1"/}}A table
 {{/figureCaption}}]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigure
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginTable
 beginTableRow
 beginTableCell
@@ -111,19 +113,21 @@ endTableCell
 endTableRow
 endTable
 beginMacroMarkerStandalone [figureCaption] [] [{{id name="t1"/}}A table]
-beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 beginFigureCaption
+beginMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+beginParagraph
 beginMacroMarkerInline [id] [name=t1]
 onId [t1]
 endMacroMarkerInline [id] [name=t1]
 onWord [A]
 onSpace
 onWord [table]
+endParagraph
+endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endFigureCaption
-endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
 endMacroMarkerStandalone [figureCaption] [] [{{id name="t1"/}}A table]
-endFigure
 endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.Block>]]
+endFigure
 endMacroMarkerStandalone [figure] [] [|a|b
 |c|d
 

--- a/application-numbered-content-reference/application-numbered-content-reference-macro/src/test/resources/references_figure_with_image_id.test
+++ b/application-numbered-content-reference/application-numbered-content-reference-macro/src/test/resources/references_figure_with_image_id.test
@@ -1,0 +1,85 @@
+.runTransformations:macro
+.#-----------------------------------------------------
+.inputexpect|xwiki/2.1
+.# Test the macro with ids specified on the image or the id and automatically generated image ids.
+.#-----------------------------------------------------
+See Figure {{reference figure="f1"/}}, {{reference figure="Iimage2.png"/}}, and {{reference figure="f3"/}}.
+
+[[An image>>image:http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png||width="100" id="f1"]]
+
+[[The second image>>image:image2.png||width="100"]]
+
+(% id="f3" %)
+[[The second image>>image:image2.png||width="100"]]
+
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<p>See Figure <span class="wikilink"><a href="#f1">1</a></span>, <span class="wikilink"><a href="#Iimage2.png">2</a></span>, and <span class="wikilink"><a href="#f3">3</a></span>.</p><img src="http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png" width="100" id="f1" alt="http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png"/><div class="figcaption"><p>An image</p></div><img src="image2.png" width="100" id="Iimage2.png" class="wikigeneratedid" alt="image2.png"/><div class="figcaption"><p>The second image</p></div><img src="image2.png" width="100" id="Iimage2.png-1" class="wikigeneratedid" alt="image2.png"/><div class="figcaption"><p>The second image</p></div>
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginParagraph
+onWord [See]
+onSpace
+onWord [Figure]
+onSpace
+beginMacroMarkerInline [reference] [figure=f1]
+beginLink [Typed = [true] Type = [doc] Reference = [] Parameters = [[anchor] = [f1]]] [false]
+onWord [1]
+endLink [Typed = [true] Type = [doc] Reference = [] Parameters = [[anchor] = [f1]]] [false]
+endMacroMarkerInline [reference] [figure=f1]
+onSpecialSymbol [,]
+onSpace
+beginMacroMarkerInline [reference] [figure=Iimage2.png]
+beginLink [Typed = [true] Type = [doc] Reference = [] Parameters = [[anchor] = [Iimage2.png]]] [false]
+onWord [2]
+endLink [Typed = [true] Type = [doc] Reference = [] Parameters = [[anchor] = [Iimage2.png]]] [false]
+endMacroMarkerInline [reference] [figure=Iimage2.png]
+onSpecialSymbol [,]
+onSpace
+onWord [and]
+onSpace
+beginMacroMarkerInline [reference] [figure=f3]
+beginLink [Typed = [true] Type = [doc] Reference = [] Parameters = [[anchor] = [f3]]] [false]
+onWord [3]
+endLink [Typed = [true] Type = [doc] Reference = [] Parameters = [[anchor] = [f3]]] [false]
+endMacroMarkerInline [reference] [figure=f3]
+onSpecialSymbol [.]
+endParagraph
+beginFigure [[class]=[image]]
+onImage [Typed = [false] Type = [url] Reference = [http://www.clker.com/cliparts/3/m/v/Y/E/V/small-red-apple-md.png]] [false] [Ihttp:2F2Fwww.clker.com2Fcliparts2F32Fm2Fv2FY2FE2FV2Fsmall-red-apple-md.png] [[id]=[f1][width]=[100]]
+beginFigureCaption
+beginParagraph
+onWord [An]
+onSpace
+onWord [image]
+endParagraph
+endFigureCaption
+endFigure [[class]=[image]]
+beginFigure [[class]=[image]]
+onImage [Typed = [false] Type = [url] Reference = [image2.png]] [false] [Iimage2.png] [[width]=[100]]
+beginFigureCaption
+beginParagraph
+onWord [The]
+onSpace
+onWord [second]
+onSpace
+onWord [image]
+endParagraph
+endFigureCaption
+endFigure [[class]=[image]]
+beginFigure [[class]=[image][id]=[f3]]
+onImage [Typed = [false] Type = [url] Reference = [image2.png]] [false] [Iimage2.png-1] [[width]=[100]]
+beginFigureCaption
+beginParagraph
+onWord [The]
+onSpace
+onWord [second]
+onSpace
+onWord [image]
+endParagraph
+endFigureCaption
+endFigure [[class]=[image][id]=[f3]]
+endDocument

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.contrib</groupId>
     <artifactId>parent-platform</artifactId>
-    <version>14.0-1</version>
+    <version>14.2</version>
   </parent>
   
   <packaging>pom</packaging>


### PR DESCRIPTION
* Use the id attribute of any block, the id of the id macro or the id generated for the image.
* Move to parent-platform 14.2 - update and add tests, do not use reflection to access the `getId` method.

Jira issue: https://jira.xwiki.org/browse/NCAPP-47

This pull request contains two commits. The first is enough to implement the id support, the second just makes it nicer by moving to parent-platform 14.2. We need to decide if we want to require 14.2 or not.